### PR TITLE
Add levels option to flatten 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node_modules/.bin/rollup -w -c ./build/rollup.config.dev.js",
     "build": "node_modules/.bin/rollup -c ./build/rollup.config.prod.js",
-    "test": "jest ./test/index.test.js --notify"
+    "test": "jest --notify"
   },
   "repository": {
     "type": "git",

--- a/src/utils/functions/normal.ts
+++ b/src/utils/functions/normal.ts
@@ -4,34 +4,63 @@
  * @LastEditTime: 2020-06-22 21:08:03
  * @LastEditors: Please set LastEditors
  * @FilePath: \ifoo\src\utils\functions\normal.ts
- */ 
-import { CONSOLE_HEADER_TEXT, CONSOLE_HEADER_STYLE } from '../../global_data';
-import { 
-    PureFunctionCompose,
-    Flatten
- } from '../functions/types/function_types';
+ */
+
+import { CONSOLE_HEADER_TEXT, CONSOLE_HEADER_STYLE } from "../../global_data";
+import {
+  PureFunctionCompose,
+  Flatten,
+  FlattenOptions,
+} from "../functions/types/function_types";
 /**
  * @description: a pipeline for functions runs a 'left to right' order
- * @param {funtion} 
+ * @param {funtion}
  * @return: a composed function
  */
 
-export const compose: PureFunctionCompose<Function> = (...fns) => x => fns.reduce((acc, f)=> {
-    if(typeof f !== "function" || f.length !== 1){
-        console.log(CONSOLE_HEADER_TEXT, CONSOLE_HEADER_STYLE, `compose accepts pure function(s) which needs only 1 argument`);
+export const compose: PureFunctionCompose<Function> = (...fns) => (x) =>
+  fns.reduce((acc, f) => {
+    if (typeof f !== "function" || f.length !== 1) {
+      console.log(
+        CONSOLE_HEADER_TEXT,
+        CONSOLE_HEADER_STYLE,
+        `compose accepts pure function(s) which needs only 1 argument`
+      );
     }
-    try{
-        return f(acc);
-    }catch(e){
-        console.log(CONSOLE_HEADER_TEXT, CONSOLE_HEADER_STYLE, e);
+    try {
+      return f(acc);
+    } catch (e) {
+      console.log(CONSOLE_HEADER_TEXT, CONSOLE_HEADER_STYLE, e);
     }
-}, x);
+  }, x);
 
-export const flatten: Flatten<number> = (arr: []) => {
-    if(Array.isArray(arr)){
-        return arr.reduce((acc, item) => Array.isArray(item)? acc.concat(flatten(item)): acc.concat(item), []);
-    }else{
-        console.log(CONSOLE_HEADER_TEXT, CONSOLE_HEADER_STYLE, `flatten accepts an array`, `and safe answer '[]' returned`);
-        return [];
-    }
-}
+export const flatten: Flatten<number> = (
+  arr: [],
+  options: FlattenOptions = { levels: Number.POSITIVE_INFINITY }
+) => {
+  const levels = options.levels ? Number(options.levels) : 0;
+
+  // Return empty if first parameter is not an array
+  if (!Array.isArray(arr)) {
+    console.log(
+      CONSOLE_HEADER_TEXT,
+      CONSOLE_HEADER_STYLE,
+      `flatten accepts an array`,
+      `and safe answer '[]' returned`
+    );
+    return [];
+  }
+
+  if (levels === 0) {
+    return arr;
+  }
+
+  // Recursively flatten the next level
+  return arr.reduce(
+    (acc, item) =>
+      Array.isArray(item)
+        ? acc.concat(flatten(item, { levels: levels - 1 }))
+        : acc.concat(item),
+    []
+  );
+};

--- a/src/utils/functions/types/function_types.ts
+++ b/src/utils/functions/types/function_types.ts
@@ -5,7 +5,20 @@
  * @LastEditors: Please set LastEditors
  * @Description: In User Settings Edit
  * @FilePath: \ifoo\src\utils\functions\types\function_types.ts
- */ 
-export type PureFunctionCompose<T> = (...f: T[]) => (x:any) => T;
+ */
 
-export type Flatten<T> = (arr: Array<Array<T>> | T[]) => T[];
+export type PureFunctionCompose<T> = (...f: T[]) => (x: any) => T;
+
+/* Optional parameters for the Flatten function */
+export type FlattenOptions = {
+  /*
+    Limit how many levels of the array will be flattened.
+    Default: 0 which will flatten all levels
+   */
+  levels: number;
+};
+
+export type Flatten<T> = (
+  arr: Array<Array<T>> | T[],
+  options?: FlattenOptions
+) => T[];

--- a/src/utils/functions/types/function_types.ts
+++ b/src/utils/functions/types/function_types.ts
@@ -13,7 +13,7 @@ export type PureFunctionCompose<T> = (...f: T[]) => (x: any) => T;
 export type FlattenOptions = {
   /*
     Limit how many levels of the array will be flattened.
-    Default: 0 which will flatten all levels
+    Default: POSITIVE_INFINITY which will flatten all levels
    */
   levels: number;
 };

--- a/test/flatten.test.js
+++ b/test/flatten.test.js
@@ -1,0 +1,43 @@
+import { flatten } from "../src/index";
+
+test("flatten([])", () => {
+  const inString = JSON.stringify([]);
+  const outString = JSON.stringify(flatten([]));
+  expect(outString).toBe(inString);
+});
+
+test("flatten([ -1, 2, 'abc'])", () => {
+  const inString = JSON.stringify([-1, 2, "abc"]);
+  const outString = JSON.stringify(flatten([-1, 2, "abc"]));
+  expect(outString).toBe(inString);
+});
+
+test("flatten([ -1, 2, ['abc'], [[[[3],[4]]]])", () => {
+  const inString = JSON.stringify([-1, 2, "abc", 3, 4]);
+  const outString = JSON.stringify(flatten([-1, 2, "abc", 3, 4]));
+  expect(outString).toBe(inString);
+});
+
+test("flatten([1, 1, [2, [3, 3], [[4]]]], { levels: 1 })", () => {
+  const inString = JSON.stringify([1, 1, 2, [3, 3], [[4]]]);
+  const outString = JSON.stringify(
+    flatten([1, 1, [2, [3, 3], [[4]]]], { levels: 1 })
+  );
+  expect(outString).toBe(inString);
+});
+
+test("flatten([1, 1, [2, [3, 3], [[4]]]], { levels: 2 })", () => {
+  const inString = JSON.stringify([1, 1, 2, 3, 3, [4]]);
+  const outString = JSON.stringify(
+    flatten([1, 1, [2, [3, 3], [[4]]]], { levels: 2 })
+  );
+  expect(outString).toBe(inString);
+});
+
+test("flatten([1, 1, [2, [3, 3], [[4]]]], { levels: 3 })", () => {
+  const inString = JSON.stringify([1, 1, 2, 3, 3, 4]);
+  const outString = JSON.stringify(
+    flatten([1, 1, [2, [3, 3], [[4]]]], { levels: 3 })
+  );
+  expect(outString).toBe(inString);
+});


### PR DESCRIPTION
Hi, this is my first contribution :) 

I take this as an exercise to learn more about typescript and about collaborating in open source projects so I might be active around here. 

This PR is adding an options argument to the flatten function that right now accepts only one option which is how many levels down should the array be flatten.

 So usage:
flatten([...]) - will flatten all arrays completely (no change) 
flatten([...], {}) - same as above
flatten([...], {levels: 0}) - will return the array as it is with now changes
flatten([...], {levels: 1}) - will flatten only the first level
flatten([...], {levels: 2}) - will flatten only the first two levels, etc

