### PR TITLE
Turn on jest in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,13 @@
  * @LastEditors: Conghao Cai🔧
  * @LastEditTime: 2020-07-03 21:56:58
  * @FilePath: /spurv/ifoo/.eslintrc.js
- */ 
+ */
 module.exports = {
     "env": {
         "browser": true,
         "es2020": true,
-        "node": true
+        "node": true,
+        "test": true
     },
     "extends": [
         "eslint:recommended",


### PR DESCRIPTION
Without **jest: true**, eslint shows errors in the test files.